### PR TITLE
Fix-bnpl-product-name

### DIFF
--- a/src/components/NewOrderAmortization.vue
+++ b/src/components/NewOrderAmortization.vue
@@ -45,7 +45,7 @@
               <th>{{ isBNPL ? order.bnpl_vendor_product.name : order.product.name }}</th>
               <th>{{ order.owner }}</th>
               <th>{{ order.serial_number }}</th>
-              <th>{{ order.business_type }}</th>
+              <th>{{ isBNPL ? "BNPL" : order.business_type }}</th>
               <th class="text-capitalize">
                 {{ order.financed_by === 'altara-bnpl' ? ((order.down_payment / order.product_price) * 100).toFixed(0) : order.down_payment_rate }} percent
               </th>

--- a/src/components/PaymentLog.vue
+++ b/src/components/PaymentLog.vue
@@ -1643,7 +1643,13 @@ export default {
         this.$LIPS(true)
         const fetchBusinessTypes = await get(this.apiUrls.businessTypes)
         this.biz_type = fetchBusinessTypes?.data?.data?.data
+        this.biz_type = this.biz_type.filter(item => {
+          return item.slug !== 'ap_bnpl'
+        })
         this.businessTypes = fetchBusinessTypes?.data?.data?.data
+        this.businessTypes = this.businessTypes.filter(item => {
+          return item.slug !== 'ap_bnpl'
+        })
         this.businessTypes = this.businessTypes.filter(item => {
           if (this.isAltaraCredit) {
             return item.slug.includes("ac_")

--- a/src/components/modals/ProductInfoModal.vue
+++ b/src/components/modals/ProductInfoModal.vue
@@ -47,6 +47,14 @@
               <td>{{ downPay }}%</td>
             </tr>
             <tr>
+              <th>Verification Status</th>
+              <td :class="[modalItem.status === 'passed' ? 'text-success' : modalItem.status === 'pending' ? 'text-warning' : 'text-danger' ]">{{ modalItem.status }}</td>
+            </tr>
+            <tr>
+              <th>Reason</th>
+              <td>{{ modalItem.reason || 'N/A' }}</td>
+            </tr>
+            <tr>
               <th>Date Created</th>
               <td>{{ modalItem.bnpl_product.created_at }}</td>
             </tr>

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -61,7 +61,7 @@ export const store = new Vuex.Store({
     ALTARAPAYAccess: [...admin, 33],
     CASHLOANAccess: [...admin, 42],
     BNPLAccess: [...admin],
-    CreditCheckAccess: [...admin, 34],
+    CreditCheckAccess: [...admin, 34, 16, 21, 22],
     CoordinatorAccess: [...admin, 32],
     months: [
       { id: "01", name: "January" },

--- a/src/views/CreditCheck/AllCreditChecks.vue
+++ b/src/views/CreditCheck/AllCreditChecks.vue
@@ -149,6 +149,7 @@
                 data-toggle="dropdown"
                 :id="'dropdownMenuButton' + creditCheck.id"
                 @click="setSelectedCreditCheck(creditCheck)"
+                :disabled="creditCheck.processed_by !== null"
               >
                 Action
               </button>

--- a/src/views/CreditCheck/AllCreditChecks.vue
+++ b/src/views/CreditCheck/AllCreditChecks.vue
@@ -213,6 +213,10 @@
                     </option>
                   </select>
                 </div>
+                <div class="form-group">
+                  <label for="reason">Reason</label>
+                  <input class="form-control" type="text" name="reason" v-model="reason" />
+                </div>
               </div>
               <div class="d-flex justify-content-end align-items-center p-4">
                 <button
@@ -256,6 +260,7 @@ export default {
 
   data() {
     return {
+      reason: null,
       branch_id: "",
       creditChecks: [],
       selectedCreditCheck: {},
@@ -374,6 +379,7 @@ export default {
       this.$LIPS(true)
       patch(`api/update/credit/checker/status/${this.selectedCreditCheck.id}`, {
         status: this.selectedStatus,
+        reason: this.reason
       })
         .then(({ data }) => {
           flash.setSuccess(data?.message)

--- a/src/views/FSL/lookup/lookup.vue
+++ b/src/views/FSL/lookup/lookup.vue
@@ -1181,6 +1181,7 @@
                 @deletePayment="deletePayment"
                 @preparePayments="preparePayments"
                 v-on:childToParent="newOrderItem"
+                :isBNPL="order.financed_by === 'altara-bnpl'"
               ></new-order-amortization>
             </div>
           </div>


### PR DESCRIPTION
-business type (bnpl) and exact product name should be displayed on the portal after logging sale via bnpl app
-restrict bnpl from being a business type/category drop-down on the sales logger
-vcr should have access to the credit check portal
--disable action button after processing credit check once